### PR TITLE
Modify Scala CI workflow for JDK 17 and caching

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,16 +8,45 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '21'
-    - name: Run tests
-      run: sbt coverage test coverageReport
-    - name: Submit coverage report
-      run: bash <(curl -s https://codecov.io/bash)
+      # Step 1: Checkout your repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Set up JDK 17
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # Step 3: Cache sbt dependencies
+      - name: Cache sbt and Ivy2
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+
+      # Step 4: Install sbt from official repo
+      - name: Install sbt
+        run: |
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x99E82A75642AC823" | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install sbt -y
+          sbt sbtVersion
+
+      # Step 5: Compile the project
+      - name: Compile
+        run: sbt compile
+
+      # Step 6: Run tests with coverage
+      - name: Run tests and generate coverage
+        run: sbt coverage test coverageReport


### PR DESCRIPTION
Updated Scala CI workflow to use JDK 17 and cache sbt dependencies.