### PR TITLE
Modify Scala CI workflow for JDK 17 and sbt installation

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,16 +8,31 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '21'
-    - name: Run tests
-      run: sbt coverage test coverageReport
-    - name: Submit coverage report
-      run: bash <(curl -s https://codecov.io/bash)
+      # Step 1: Checkout your repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Set up Java (Scala requires JVM)
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # Step 3: Install sbt
+      - name: Install sbt
+        run: |
+          curl -L -o sbt.deb https://github.com/sbt/sbt/releases/download/v1.9.4/sbt-1.9.4.deb
+          sudo dpkg -i sbt.deb
+          sbt sbtVersion
+
+      # Step 4: Compile the project
+      - name: Compile
+        run: sbt compile
+
+      # Step 5: Run tests with coverage
+      - name: Run tests with coverage
+        run: sbt coverage test coverageReport


### PR DESCRIPTION
Updated GitHub Actions workflow for Scala project to use JDK 17 and install sbt.